### PR TITLE
Correct Repository in README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
 
       - name: Netbird Connect
         id: netbird
-        uses: Alemiz112/netbird-connect-action@v1
+        uses: Alemiz112/netbird-connect@v1
         with:
           setup-key: ${{ secrets.NETBIRD_SETUP_KEY }}
           hostname: 'my-custom-hostname'


### PR DESCRIPTION
The example in the README doesn't work because the repository in the `uses` field is doesn't resolve. After an educated test this was the value I used to get it working.