### PR TITLE
Cache the netbird installer

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,11 +28,26 @@ runs:
       run: |
         echo "::error title=error hint::Support Linux Only"
         exit 1
+    - name: Cache Netbird Installer
+      id: cache-netbird-installer
+      uses: actions/cache@v4
+      with:
+        path: netbird-installer
+        key: netbird-installer
     - name: Download Netbird
       shell: bash
       env:
         USE_BIN_INSTALL: true
-      run: curl -fsSL https://pkgs.netbird.io/install.sh | sh
+      run: >
+        curl --fail --no-progress-meter --location
+        --etag-save netbird-installer/etag.txt --etag-compare netbird-installer/etag.txt
+        --write-out "HTTP Code from fetching installer : %{http_code}\n"
+        --output netbird-installer/install.sh
+        https://pkgs.netbird.io/install.sh
+        
+        chmod 755 netbird-installer/install.sh
+        
+        netbird-installer/install.sh
     - name: Connect to Netbird
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,8 @@ runs:
       env:
         USE_BIN_INSTALL: true
       run: >
+        mkdir -p netbird-installer
+        
         curl --fail --no-progress-meter --location
         --etag-save netbird-installer/etag.txt --etag-compare netbird-installer/etag.txt
         --write-out "HTTP Code from fetching installer : %{http_code}\n"

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         exit 1
     - name: Cache Netbird Installer
       id: cache-netbird-installer
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: netbird-installer
         key: netbird-installer


### PR DESCRIPTION
This uses the actions/cache action to cache the `install.sh` file and to store the ETag for it to prevent fetching it unless the content changes.

This also writes out the HTTP code of the fetch so it's clear in the output for the action when it's using the cached `install.sh`